### PR TITLE
pick_image: Gallery typo while picking Image

### DIFF
--- a/lib/pick_image.dart
+++ b/lib/pick_image.dart
@@ -76,7 +76,7 @@ class PickImage extends StatelessWidget {
                             ),
                           ),
                           Text(
-                            "Galery",
+                            "Gallery",
                             style: TextStyle(color: color ?? Colors.black45),
                           ),
                         ],


### PR DESCRIPTION
Fixes the typo "Galery" to "Gallery"